### PR TITLE
Fix shell prompt not to show () around a topology name

### DIFF
--- a/cmd/lib/shell/controller.go
+++ b/cmd/lib/shell/controller.go
@@ -54,9 +54,9 @@ func (a *App) prompt(line *liner.State) {
 	// for a continued statement will be shown)
 	getNextLine := func(continued bool) (string, error) {
 		// create prompt
-		promptStart := "(no topology)" + promptLineStart
+		promptStart := promptLineStart
 		if currentTopology.name != "" {
-			promptStart = fmt.Sprintf("(%s)%s", currentTopology.name,
+			promptStart = fmt.Sprintf("%s%s", currentTopology.name,
 				promptLineStart)
 		}
 		if continued {


### PR DESCRIPTION
This PR removes () from shell prompt. fixes #4 
