### PR TITLE
modify timestamp <-> int convert spec

### DIFF
--- a/bql/udf/generic_func_test.go
+++ b/bql/udf/generic_func_test.go
@@ -607,7 +607,8 @@ func TestGenericFuncInconvertibleType(t *testing.T) {
 			{"negative int", data.Int(int64(math.MinInt32) - 1)},
 			{"float", data.Float(float64(math.MaxInt32) + 1.0)},
 			{"negative float", data.Float(float64(math.MinInt32) - 1.0)},
-			{"time", data.Timestamp(time.Date(2015, time.May, 1, 14, 27, 0, 0, time.UTC))},
+			// unix time of MaxInt32 = 2038-01-19 3:14:07
+			{"time", data.Timestamp(time.Date(2038, time.January, 19, 3, 14, 8, 0, time.UTC))},
 		},
 		{ // int64
 			{"float", data.Float(float64(math.MaxUint64))},
@@ -632,7 +633,8 @@ func TestGenericFuncInconvertibleType(t *testing.T) {
 			{"negative int", data.Int(-1)},
 			{"float", data.Float(float64(math.MaxUint32) + 1.0)},
 			{"negative float", data.Float(-1.0)},
-			{"time", data.Timestamp(time.Date(2015, time.May, 1, 14, 27, 0, 0, time.UTC))},
+			// unix time of MaxUint32 = 2106-02-07 06:28:15
+			{"time", data.Timestamp(time.Date(2106, time.February, 7, 6, 28, 16, 0, time.UTC))},
 		},
 		{ // uint64
 			{"negative int", data.Int(-1)},

--- a/data/type_conversions_test.go
+++ b/data/type_conversions_test.go
@@ -105,9 +105,9 @@ func TestToInt(t *testing.T) {
 		"Timestamp": {
 			// The zero value for a time.Time is *not* the timestamp
 			// that has unix time zero!
-			{"zero", Timestamp(time.Time{}), int64(-62135596800000000)},
-			{"now", Timestamp(now), now.UnixNano() / 1000},
-			{"negative", Timestamp(negTime), negTime.UnixNano() / 1000},
+			{"zero", Timestamp(time.Time{}), int64(-62135596800)},
+			{"now", Timestamp(now), now.Unix()},
+			{"negative", Timestamp(negTime), negTime.Unix()},
 		},
 		"Array": {
 			{"empty", Array{}, nil},
@@ -307,10 +307,8 @@ func TestToTimestamp(t *testing.T) {
 			{"false", Bool(false), nil},
 		},
 		"Int": {
-			{"positive", Int(2), time.Unix(0, 2000)},
-			{"negative", Int(-2), time.Unix(0, -2000)},
-			{"large and positive", Int(2e6), time.Unix(2, 0)},
-			{"large and negative", Int(-2e6), time.Unix(-2, 0)},
+			{"positive", Int(2), time.Unix(2, 0)},
+			{"negative", Int(-2), time.Unix(-2, 0)},
 			{"zero", Int(0), time.Unix(0, 0)},
 		},
 		"Float": {

--- a/data/value_test.go
+++ b/data/value_test.go
@@ -15,7 +15,7 @@ import (
 func TestUnmarshalMsgpack(t *testing.T) {
 	Convey("Given a msgpack byte data", t, func() {
 		now := time.Now()
-		microTime := now.UnixNano() / 1000
+		unixTime := now.Unix()
 		var testMap = map[string]interface{}{
 			"bool":    true,
 			"int32":   int32(1),
@@ -23,7 +23,7 @@ func TestUnmarshalMsgpack(t *testing.T) {
 			"float32": float32(0.1),
 			"float64": float64(0.2),
 			"string":  "homhom",
-			"time":    int64(microTime),
+			"time":    int64(unixTime),
 			"array": []interface{}{true, 10, "inarray",
 				map[string]interface{}{
 					"mapinarray": "arraymap",
@@ -48,7 +48,7 @@ func TestUnmarshalMsgpack(t *testing.T) {
 					"float32": Float(float32(0.1)),
 					"float64": Float(0.2),
 					"string":  String("homhom"),
-					"time":    Int(microTime),
+					"time":    Int(unixTime),
 					"array": Array([]Value{Bool(true), Int(10), String("inarray"),
 						Map{
 							"mapinarray": String("arraymap"),
@@ -158,7 +158,7 @@ func TestNewMapIncludeUnsupportedValue(t *testing.T) {
 func TestMarshalMsgpack(t *testing.T) {
 	Convey("Given a Map object data", t, func() {
 		now := time.Now()
-		milliSecond := now.UnixNano() / 1000
+		unitTime := now.Unix()
 		var testMap = Map{
 			"bool":   Bool(true),
 			"int":    Int(1),
@@ -185,7 +185,7 @@ func TestMarshalMsgpack(t *testing.T) {
 					"int":    int64(1),
 					"float":  float64(0.1),
 					"string": "homhom",
-					"time":   milliSecond,
+					"time":   unitTime,
 					"array": []interface{}{true, 10, "inarray",
 						map[string]interface{}{
 							"mapinarray": "arraymap",


### PR DESCRIPTION
int to timestamp: int value means unix time as second part
timestamp to int: return second part as unix time

```
hoge> EVAL (1.5::timestamp)::int;
1
hoge> EVAL (1::timestamp)::int;
1
```

fixes #2 
