### PR TITLE
Support cli.ActionFunc to suppress cli's DEPRECATED message

### DIFF
--- a/cmd/lib/exp/clean.go
+++ b/cmd/lib/exp/clean.go
@@ -22,7 +22,7 @@ func setUpClean() cli.Command {
 	return cmd
 }
 
-func runClean(c *cli.Context) {
+func runClean(c *cli.Context) error {
 	err := func() (retErr error) {
 		cache, err := LoadCacheFromFile(cacheInfoFilename)
 		if err != nil {
@@ -52,9 +52,9 @@ func runClean(c *cli.Context) {
 		return nil
 	}()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		return cli.NewExitError(err.Error(), 1)
 	}
+	return nil
 }
 
 func removeCacheFile(ent *CacheEntry) error {

--- a/cmd/lib/exp/file.go
+++ b/cmd/lib/exp/file.go
@@ -23,7 +23,7 @@ func setUpFile() cli.Command {
 	return cmd
 }
 
-func runFile(c *cli.Context) {
+func runFile(c *cli.Context) error {
 	err := func() error {
 		if len(c.Args()) != 1 {
 			cli.ShowSubcommandHelp(c)
@@ -61,7 +61,7 @@ func runFile(c *cli.Context) {
 		return nil
 	}()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		return cli.NewExitError(err.Error(), 1)
 	}
+	return nil
 }

--- a/cmd/lib/exp/run.go
+++ b/cmd/lib/exp/run.go
@@ -57,7 +57,7 @@ const (
 	cacheInfoFilename = ".sensorbee-exp-cache" // TODO: this should be an option
 )
 
-func runRun(c *cli.Context) {
+func runRun(c *cli.Context) error {
 	err := func() error {
 		if a := c.Args(); len(a) != 1 {
 			cli.ShowSubcommandHelp(c)
@@ -108,9 +108,9 @@ func runRun(c *cli.Context) {
 		return nil
 	}()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		return cli.NewExitError(err.Error(), 1)
 	}
+	return nil
 }
 
 func findCache(cache *Cache, stmts *Statements) int {

--- a/cmd/lib/run/cmd.go
+++ b/cmd/lib/run/cmd.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
 )
 
 // SetUp sets up SensorBee's HTTP server. The URL or port ID is set with server
@@ -37,92 +36,82 @@ func SetUp() cli.Command {
 }
 
 // Run run the HTTP server.
-func Run(c *cli.Context) {
-	defer func() {
-		// This logic is provided to write test codes for this command line tool like below:
-		// if v := recover(); v != nil {
-		//   if testMode {
-		//     testExitStatus = v.(int)
-		//   } else {
-		//     os.Exit(v.(int))
-		//   }
-		// }
-		if v := recover(); v != nil {
-			os.Exit(v.(int))
+func Run(c *cli.Context) error {
+	err := func() error {
+		var conf *config.Config
+		if c.IsSet("config") {
+			p := c.String("config")
+			in, err := ioutil.ReadFile(p)
+			if err != nil {
+				return fmt.Errorf("Cannot read the config file %v: %v", p, err)
+			}
+
+			var yml map[string]interface{}
+			if err := yaml.Unmarshal(in, &yml); err != nil {
+				return fmt.Errorf("Cannot parse the config file %v: %v", p, err)
+			}
+			m, err := data.NewMap(yml)
+			if err != nil {
+				return fmt.Errorf("The config file %v has invalid values: %v", p, err)
+			}
+			c, err := config.New(m)
+			if err != nil {
+				return fmt.Errorf("Cannot apply the cnofig file %v: %v", p, err)
+			}
+			conf = c
+
+		} else {
+			// Currently there's no required parameters. However, when a required
+			// parameter is added to Config, remove this else block and add a
+			// default value like "/etc/sensorbee/config.yaml" to the config option.
+			c, err := config.New(data.Map{})
+			if err != nil {
+				return fmt.Errorf("Cannot apply the default config: %v", err)
+			}
+			conf = c
 		}
+
+		cgvars, err := server.SetUpContextGlobalVariables(conf)
+		if err != nil {
+			return fmt.Errorf("Cannot set up the server context: %v", err)
+		}
+
+		cgvars.Logger.WithField("config", conf.ToMap()).Info("Setting up the server context")
+
+		jascoRoot := jasco.New("/", cgvars.Logger)
+		router, err := server.SetUpContextAndRouter("/", jascoRoot, cgvars)
+		if err != nil {
+			return fmt.Errorf("Cannot set up the server context: %v", err)
+		}
+		server.SetUpAPIRouter("/", router, nil)
+
+		bind := c.String("listen-on")
+		if _, err := net.ResolveTCPAddr("tcp", bind); err != nil {
+			return fmt.Errorf("--listen-on(-l) parameter has an invalid address: %v", err)
+		}
+
+		// TODO: support listening on multiple addresses
+		// TODO: support stopping the server
+		// TODO: support graceful shutdown
+		s := &http.Server{
+			Addr:    conf.Network.ListenOn,
+			Handler: jascoRoot,
+		}
+		cgvars.Logger.Infof("Starting the server on %v", conf.Network.ListenOn)
+		if err := s.ListenAndServe(); err != nil {
+			return fmt.Errorf("Cannot start the server: %v", err)
+		}
+		cgvars.Logger.Infof("The server stopped")
+		return nil
 	}()
-
-	var conf *config.Config
-	if c.IsSet("config") {
-		p := c.String("config")
-		in, err := ioutil.ReadFile(p)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Cannot read the config file %v: %v\n", p, err)
-			panic(1)
-		}
-
-		var yml map[string]interface{}
-		if err := yaml.Unmarshal(in, &yml); err != nil {
-			fmt.Fprintf(os.Stderr, "Cannot parse the config file %v: %v\n", p, err)
-			panic(1)
-		}
-		m, err := data.NewMap(yml)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "The config file %v has invalid values: %v\n", p, err)
-			panic(1)
-		}
-		c, err := config.New(m)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Cannot apply the cnofig file %v: %v\n", p, err)
-			panic(1)
-		}
-		conf = c
-
-	} else {
-		// Currently there's no required parameters. However, when a required
-		// parameter is added to Config, remove this else block and add a
-		// default value like "/etc/sensorbee/config.yaml" to the config option.
-		c, err := config.New(data.Map{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Cannot apply the default config: %v\n", err)
-			panic(1)
-		}
-		conf = c
-	}
-
-	cgvars, err := server.SetUpContextGlobalVariables(conf)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Cannot set up the server context: %v\n", err)
-		panic(1)
+		// NOTE: using something like this allows tests to check exit codes.
+		//   if testMode {
+		//     testExitStatus = ec
+		//   } else {
+		//     return cli.NewExitError(err.Error(), 1)
+		//   }
+		return cli.NewExitError(err.Error(), 1)
 	}
-
-	cgvars.Logger.WithField("config", conf.ToMap()).Info("Setting up the server context")
-
-	jascoRoot := jasco.New("/", cgvars.Logger)
-	router, err := server.SetUpContextAndRouter("/", jascoRoot, cgvars)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Cannot set up the server context: %v\n", err)
-		panic(1)
-	}
-	server.SetUpAPIRouter("/", router, nil)
-
-	bind := c.String("listen-on")
-	if _, err := net.ResolveTCPAddr("tcp", bind); err != nil {
-		fmt.Fprintln(os.Stderr, "--listen-on(-l) parameter has an invalid address:", err)
-		panic(1)
-	}
-
-	// TODO: support listening on multiple addresses
-	// TODO: support stopping the server
-	// TODO: support graceful shutdown
-	s := &http.Server{
-		Addr:    conf.Network.ListenOn,
-		Handler: jascoRoot,
-	}
-	cgvars.Logger.Infof("Starting the server on %v", conf.Network.ListenOn)
-	if err := s.ListenAndServe(); err != nil {
-		fmt.Fprintln(os.Stderr, "Cannot start the server:", err)
-		panic(1)
-	}
-	cgvars.Logger.Infof("The server stopped")
+	return nil
 }

--- a/cmd/lib/shell/controller.go
+++ b/cmd/lib/shell/controller.go
@@ -26,7 +26,7 @@ func SetUpCommands(commands []Command) App {
 	if runtime.GOOS == "windows" {
 		histDir = path.Join(os.Getenv("APPDATA"), "PFN", "SensorBee")
 		if err := os.MkdirAll(histDir, os.ModeDir); err != nil {
-			fmt.Printf("failed to create application directory '%s': %s\n", histDir, err)
+			fmt.Fprintf(os.Stderr, "failed to create application directory '%s': %s\n", histDir, err)
 		}
 	}
 

--- a/cmd/lib/topology/cmd_test.go
+++ b/cmd/lib/topology/cmd_test.go
@@ -107,7 +107,7 @@ func TestTopologyCommand(t *testing.T) {
 
 			Convey("Then creating another topology having the same name should fail", func() {
 				out, err := newApp(s.URL()).run("create", "test_topology")
-				So(err, ShouldBeNil)
+				So(err, ShouldNotBeNil)
 				So(out, ShouldBeBlank)
 				So(testExitCode, ShouldNotEqual, 0)
 			})
@@ -155,7 +155,7 @@ func TestTopologyCreateCommandValidation(t *testing.T) {
 			c := c
 			Convey(c.title, func() {
 				out, err := newApp(url).rawRun("create", c.args...)
-				So(err, ShouldBeNil)
+				So(err, ShouldNotBeNil)
 				So(out, ShouldBeBlank)
 
 				Convey("Then the exit code shouldn't be 0", func() {
@@ -189,7 +189,7 @@ func TestTopologyListCommandValidation(t *testing.T) {
 			c := c
 			Convey(c.title, func() {
 				out, err := newApp(url).rawRun("list", c.args...)
-				So(err, ShouldBeNil)
+				So(err, ShouldNotBeNil)
 				So(out, ShouldBeBlank)
 
 				Convey("Then the exit code shouldn't be 0", func() {
@@ -225,7 +225,7 @@ func TestTopologyDropCommandValidation(t *testing.T) {
 			c := c
 			Convey(c.title, func() {
 				out, err := newApp(url).rawRun("drop", c.args...)
-				So(err, ShouldBeNil)
+				So(err, ShouldNotBeNil)
 				So(out, ShouldBeBlank)
 
 				Convey("Then the exit code shouldn't be 0", func() {

--- a/cmd/lib/topology/create.go
+++ b/cmd/lib/topology/create.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/codegangsta/cli"
 	"gopkg.in/sensorbee/sensorbee.v0/client"
-	"os"
 )
 
 func setUpCreate() cli.Command {
@@ -13,29 +12,32 @@ func setUpCreate() cli.Command {
 		Aliases:     []string{"c"},
 		Usage:       "create a new topology",
 		Description: "sensorbee topology create <topology_name> create a new topology having <topology_name>.",
-		Action:      runCreate,
+		Action:      actionWrapper(runCreate),
 		Flags:       commonFlags,
 	}
 }
 
-func runCreate(c *cli.Context) {
-	defer panicHandler()
-	validateFlags(c)
+func runCreate(c *cli.Context) error {
+	if err := validateFlags(c); err != nil {
+		return err
+	}
 
 	args := c.Args()
 	switch l := len(args); l {
 	case 1:
 		// ok
 	case 0:
-		fmt.Fprintln(os.Stderr, "topology_name is missing")
-		panic(1) // TODO: define exit code properly
+		return fmt.Errorf("topology_name is missing")
 	default:
-		fmt.Fprintln(os.Stderr, "too many command line arguments")
-		panic(1)
+		return fmt.Errorf("too many command line arguments")
 	}
 
-	do(c, client.Post, "topologies", map[string]interface{}{
+	res, err := do(c, client.Post, "topologies", map[string]interface{}{
 		"name": args[0],
-	}, "Cannot create a topology").Close()
+	}, "Cannot create a topology")
+	if err != nil {
+		return err
+	}
 	// TODO: show something about the created topology
+	return res.Close()
 }

--- a/cmd/lib/topology/list.go
+++ b/cmd/lib/topology/list.go
@@ -5,7 +5,6 @@ import (
 	"github.com/codegangsta/cli"
 	"gopkg.in/sensorbee/sensorbee.v0/client"
 	"gopkg.in/sensorbee/sensorbee.v0/server/response"
-	"os"
 )
 
 func setUpList() cli.Command {
@@ -14,32 +13,35 @@ func setUpList() cli.Command {
 		Aliases:     []string{"l"},
 		Usage:       "get a list of topologies",
 		Description: "list commands show a list of names of topologies in the server",
-		Action:      runList,
+		Action:      actionWrapper(runList),
 		Flags:       commonFlags,
 		// TODO: add flags like "ls -l"
 		// TODO: maybe pagination?
 	}
 }
 
-func runList(c *cli.Context) {
-	defer panicHandler()
-	validateFlags(c)
-
-	if len(c.Args()) > 0 {
-		fmt.Fprintln(os.Stderr, "too many command line arguments")
-		panic(1)
+func runList(c *cli.Context) error {
+	if err := validateFlags(c); err != nil {
+		return err
 	}
 
-	res := do(c, client.Get, "topologies", nil, "Cannot get a list of topologies")
+	if len(c.Args()) > 0 {
+		return fmt.Errorf("too many command line arguments")
+	}
+
+	res, err := do(c, client.Get, "topologies", nil, "Cannot get a list of topologies")
+	if err != nil {
+		return err
+	}
 	ts := struct {
 		Topologies []*response.Topology `json:"topologies"`
 	}{}
 	if err := res.ReadJSON(&ts); err != nil { // ReadJSON closes the body
-		fmt.Fprintf(os.Stderr, "Cannot read a response: %v\n", err)
-		panic(1)
+		return fmt.Errorf("Cannot read a response: %v", err)
 	}
 
 	for _, t := range ts.Topologies {
 		fmt.Fprintln(c.App.Writer, t.Name)
 	}
+	return nil
 }

--- a/cmd/sensorbee/default_main.go
+++ b/cmd/sensorbee/default_main.go
@@ -21,7 +21,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sensorbee"
 	app.Usage = "SensorBee"
-	app.Version = "0.3.2" // TODO get dynamic, will be get from external file
+	app.Version = "0.3.2" // TODO: don't hardcode the version number
 	app.Commands = []cli.Command{
 		run.SetUp(),
 		shell.SetUp(),


### PR DESCRIPTION
This commit also changes some actions not to use panic/recover for termination processing.

fixes #60 

After merging this PR, we need to bump the version to 0.4.2. At that time, we should resolve the issue #13 and stop hardcoding the version number in build_sensorbee/main.go.