### PR TITLE
Trim names of UDSs given by --save-uds

### DIFF
--- a/cmd/lib/runfile/cmd.go
+++ b/cmd/lib/runfile/cmd.go
@@ -267,6 +267,9 @@ func saveStates(tb *bql.TopologyBuilder, saveUDSList string) error {
 		}
 	} else {
 		saveUDSs = strings.Split(saveUDSList, ",")
+		for i, n := range saveUDSs {
+			saveUDSs[i] = strings.TrimSpace(n)
+		}
 	}
 
 	saveErrorFlag := false


### PR DESCRIPTION
I fixed the code to trim leading/trailing spaces of names.

fixes #22 