### PR TITLE
add bql command, same function as "sensorbee shell"

### DIFF
--- a/cmd/bql/bql_main.go
+++ b/cmd/bql/bql_main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/codegangsta/cli"
+	"gopkg.in/sensorbee/sensorbee.v0/cmd/lib/shell"
+	"gopkg.in/sensorbee/sensorbee.v0/version"
+	"os"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "bql"
+	app.Usage = "bql command launches an interactive shell for BQL"
+	app.Version = version.Version
+	app.Flags = shell.CmdFlags
+	app.Action = shell.Launch
+
+	app.Run(os.Args)
+}

--- a/cmd/lib/shell/cmd_line_tool.go
+++ b/cmd/lib/shell/cmd_line_tool.go
@@ -16,24 +16,27 @@ func SetUp() cli.Command {
 		Description: "shell command launches an interactive shell for BQL",
 		Action:      Launch,
 	}
-	cmd.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:   "uri",
-			Value:  fmt.Sprintf("http://localhost:%d/", config.DefaultPort),
-			Usage:  "the address of the target SensorBee server",
-			EnvVar: "SENSORBEE_URI",
-		},
-		cli.StringFlag{
-			Name:  "api-version",
-			Value: "v1",
-			Usage: "target API version",
-		},
-		cli.StringFlag{
-			Name:  "topology,t",
-			Usage: "the SensorBee topology to use (instead of USE command)",
-		},
-	}
+	cmd.Flags = CmdFlags
 	return cmd
+}
+
+// CmdFlags is list of shell command options
+var CmdFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:   "uri",
+		Value:  fmt.Sprintf("http://localhost:%d/", config.DefaultPort),
+		Usage:  "the address of the target SensorBee server",
+		EnvVar: "SENSORBEE_URI",
+	},
+	cli.StringFlag{
+		Name:  "api-version",
+		Value: "v1",
+		Usage: "target API version",
+	},
+	cli.StringFlag{
+		Name:  "topology,t",
+		Usage: "the SensorBee topology to use (instead of USE command)",
+	},
 }
 
 // Launch SensorBee's command line client tool.


### PR DESCRIPTION
refs #55 

```
$ cd /path/to/sensorbee/cmd/bql
$ go install
```

then

```
$ bql -t test
test>
```