### PR TITLE
Add new parameters to the built-in file source

### DIFF
--- a/bql/builtin.go
+++ b/bql/builtin.go
@@ -42,7 +42,16 @@ type readerSource struct {
 	filename string
 	tsField  data.Path
 	ioParams *IOParams
-	repeat   int64
+
+	// repeat is the number of times that the input data is read. When its value
+	// is less than 0, the source will read the input again and again until it's
+	// stopped. When the value is 0, the source only read the input once. When
+	// the value is k (> 0), the input is read k+1 times including the first run.
+	repeat int64
+
+	// interval is the interval between emissions of two consecutive tuples.
+	// When its value is less than or equal to 0, the source tries to emit
+	// tuples as fast as possible.
 	interval time.Duration
 	stopCh   chan struct{}
 }

--- a/bql/builtin_test.go
+++ b/bql/builtin_test.go
@@ -1,0 +1,175 @@
+package bql
+
+import (
+	"fmt"
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/sensorbee/sensorbee.v0/core"
+	"gopkg.in/sensorbee/sensorbee.v0/data"
+	"io"
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+type testFileWriter struct {
+	m   sync.Mutex
+	c   *sync.Cond
+	cnt int
+	tss []time.Time
+}
+
+func (w *testFileWriter) Write(ctx *core.Context, t *core.Tuple) error {
+	w.m.Lock()
+	defer w.m.Unlock()
+	w.cnt++
+	w.tss = append(w.tss, t.Timestamp)
+	w.c.Broadcast()
+	return nil
+}
+
+func (w *testFileWriter) wait(n int) {
+	w.m.Lock()
+	defer w.m.Unlock()
+	for w.cnt < n {
+		w.c.Wait()
+	}
+}
+
+func TestFileSource(t *testing.T) {
+	f, err := ioutil.TempFile("", "sbtest_bql_file_source")
+	if err != nil {
+		t.Fatal("Cannot create a temp file:", err)
+	}
+	name := f.Name()
+	defer func() {
+		os.Remove(name)
+	}()
+	now := time.Now()
+	nowTs := data.Timestamp(now)
+
+	// an empty line is intentionally included
+	_, err = io.WriteString(f, fmt.Sprintf(`{"int":1, "ts":%v}
+ 
+ {"int":2, "ts":%v}
+  {"int":3, "ts":%v} `, nowTs, nowTs, nowTs))
+	f.Close()
+	if err != nil {
+		t.Fatal("Cannot write to the temp file:", err)
+	}
+
+	Convey("Given a file", t, func() {
+		ctx := core.NewContext(nil)
+		params := data.Map{"path": data.String(name)}
+		w := &testFileWriter{}
+		w.c = sync.NewCond(&w.m)
+
+		Convey("When reading the file by file source with default params", func() {
+			s, err := createFileSource(ctx, &IOParams{}, params)
+			So(err, ShouldBeNil)
+			Reset(func() {
+				s.Stop(ctx)
+			})
+
+			err = s.GenerateStream(ctx, w)
+			So(err, ShouldBeNil)
+
+			Convey("Then it should emit all tuples", func() {
+				So(w.cnt, ShouldEqual, 3)
+			})
+		})
+
+		Convey("When reading the file with custom timestamp field", func() {
+			params["timestamp_field"] = data.String("ts")
+			s, err := createFileSource(ctx, &IOParams{}, params)
+			So(err, ShouldBeNil)
+			Reset(func() {
+				s.Stop(ctx)
+			})
+
+			err = s.GenerateStream(ctx, w)
+			So(err, ShouldBeNil)
+
+			Convey("Then it should emit all tuples", func() {
+				So(w.cnt, ShouldEqual, 3)
+			})
+
+			Convey("Then it should have custom timestamps", func() {
+				So(w.tss, ShouldHaveLength, w.cnt)
+				for _, ts := range w.tss {
+					So(ts, ShouldHappenOnOrBetween, now, now)
+				}
+			})
+		})
+
+		Convey("When reading the file with rewindable", func() {
+			params["rewindable"] = data.True
+			s, err := createFileSource(ctx, &IOParams{}, params)
+			So(err, ShouldBeNil)
+			Reset(func() {
+				s.Stop(ctx)
+			})
+
+			ch := make(chan error, 1)
+			go func() {
+				ch <- s.GenerateStream(ctx, w)
+			}()
+
+			Convey("Then it should write all tuples and pause", func() {
+				w.wait(3)
+				So(w.cnt, ShouldEqual, 3)
+				select {
+				case <-ch:
+					So("The source should not have stopped yet", ShouldBeNil)
+				default:
+				}
+			})
+
+			Convey("Then it should be able to rewind", func() {
+				w.wait(3)
+				rs := s.(core.RewindableSource)
+				So(rs.Rewind(ctx), ShouldBeNil)
+				w.wait(6)
+				So(w.cnt, ShouldEqual, 6)
+				select {
+				case <-ch:
+					So("The source should not have stopped yet", ShouldBeNil)
+				default:
+				}
+			})
+
+			Convey("Then it should be able to stop", func() {
+				So(s.Stop(ctx), ShouldBeNil)
+				err := <-ch
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("When creating a file source with invalid parameters", func() {
+			Convey("Then missing path parameter should result in an error", func() {
+				delete(params, "path")
+				_, err := createFileSource(ctx, &IOParams{}, params)
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Then ill-formed timestamp_path should result in an error", func() {
+				params["timestamp_field"] = data.String("/this/isnt/a/xpath")
+				_, err := createFileSource(ctx, &IOParams{}, params)
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Then invalid timestamp_path value should result in an error", func() {
+				params["timestamp_field"] = data.True
+				_, err := createFileSource(ctx, &IOParams{}, params)
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Then invalid rewindable value should result in an error", func() {
+				params["rewindable"] = data.Int(1)
+				_, err := createFileSource(ctx, &IOParams{}, params)
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+}


### PR DESCRIPTION
I added two new parameters to `file` source: `repeat` and `interval`.

`repeat` has similar functionality to `loop` proposed in #29. Instead of choosing looping forever or not, `repeat` parameter allows a source to be rewound for the specified number of times. If the value is negative, it acts just like `loop = true`.

`interval` parameter has the same implementation as `node_statuses` source.

fixes #29 