### PR TITLE
Fix defaultBoxNode.StopOnDisconnect to handle Outbound correctly

### DIFF
--- a/core/default_box_node.go
+++ b/core/default_box_node.go
@@ -107,7 +107,8 @@ func (db *defaultBoxNode) StopOnDisconnect(dir ConnDir) {
 
 	if dir&Inbound != 0 {
 		db.srcs.stopOnDisconnect()
-	} else if dir&Outbound != 0 {
+	}
+	if dir&Outbound != 0 {
 		if db.dsts.len() == 0 {
 			db.stop()
 		}


### PR DESCRIPTION
`StopOnDisconnect` wasn't able to stop when the argument is `Inbound | Outbound` and there's no outbound connection.

fix #34 