### PR TITLE
Fix .travis.yml for gopkg.in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,15 @@ before_install:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/pierrre/gotestcover
+  # For gopkg.in.
+  # Partly copied and modified under MIT license from brotli-go at https://github.com/kothar/brotli-go
+  # https://github.com/YukinobuKurata/YouTubeMagicBuyButton/blob/master/MIT-LICENSE.txt
+  - export SENSORBEE_CANONICAL_IMPORT=${GOPATH}/src/gopkg.in/sensorbee/sensorbee.v0
+  - mkdir -p ${SENSORBEE_CANONICAL_IMPORT}
+  - rsync -az ${TRAVIS_BUILD_DIR}/ ${SENSORBEE_CANONICAL_IMPORT}/
+  - cd ${SENSORBEE_CANONICAL_IMPORT}
+  - rm -rf ${TRAVIS_BUILD_DIR}
+  - export TRAVIS_BUILD_DIR=${SENSORBEE_CANONICAL_IMPORT}
 
 install:
   - go get -t -d -v ./...


### PR DESCRIPTION
sensorbee needs to be placed under gopkg.in/sensorbee/sensorbee.v0. However, it's currently copied at github.com/sensorbee/sensorbee and all tests have not been actually working properly.

https://github.com/kothar/brotli-go/pull/18 was very helpful.