### PR TITLE
Move buffer size check to core package from bql

### DIFF
--- a/bql/topology_builder.go
+++ b/bql/topology_builder.go
@@ -23,10 +23,6 @@ type TopologyBuilder struct {
 	UDSStorage     udf.UDSStorage
 }
 
-const (
-	MaxBufferSize int64 = 1<<17 - 1
-)
-
 // TODO: Provide AtomicTopologyBuilder which support building multiple nodes
 // in an atomic manner (kind of transactionally)
 
@@ -465,15 +461,6 @@ func (tb *TopologyBuilder) createStreamAsSelectStmt(stmt *parser.CreateStreamAsS
 			}
 			// set capacity of input pipe
 			if rel.Capacity != parser.UnspecifiedCapacity {
-				if rel.Capacity > MaxBufferSize {
-					return nil, fmt.Errorf("specified buffer capacity %d is too large "+
-						"(must be <= %d)",
-						rel.Capacity, MaxBufferSize)
-				} else if rel.Capacity < 0 {
-					// the parser should not allow this to happen, actually
-					return nil, fmt.Errorf("specified buffer capacity %d must not be negative",
-						rel.Capacity)
-				}
 				conf.Capacity = int(rel.Capacity)
 			}
 			// set drop mode for box

--- a/core/default_box_node.go
+++ b/core/default_box_node.go
@@ -34,6 +34,9 @@ func (db *defaultBoxNode) Input(refname string, config *BoxInputConfig) error {
 	if config == nil {
 		config = defaultBoxInputConfig
 	}
+	if err := config.Validate(); err != nil {
+		return err
+	}
 
 	if err := checkBoxInputName(db.box, db.name, config.inputName()); err != nil {
 		return err

--- a/core/default_sink_node.go
+++ b/core/default_sink_node.go
@@ -41,6 +41,9 @@ func (ds *defaultSinkNode) Input(refname string, config *SinkInputConfig) error 
 	if config == nil {
 		config = defaultSinkInputConfig
 	}
+	if err := config.Validate(); err != nil {
+		return err
+	}
 
 	recv, send := newPipe("output", config.capacity())
 	send.dropMode = config.DropMode

--- a/core/node.go
+++ b/core/node.go
@@ -264,6 +264,21 @@ const (
 	Outbound
 )
 
+const (
+	// MaxCapacity is the maximum capacity or buffer size of pipes.
+	MaxCapacity int = 1<<17 - 1
+)
+
+func validateCapacity(c int) error {
+	if c > MaxCapacity {
+		return fmt.Errorf("specified buffer capacity %d is too large (must be <= %d)",
+			c, MaxCapacity)
+	} else if c < 0 {
+		return fmt.Errorf("specified buffer capacity %d must not be negative", c)
+	}
+	return nil
+}
+
 // BoxInputConfig has parameters to customize input behavior of a Box on each
 // input pipe.
 type BoxInputConfig struct {
@@ -271,15 +286,20 @@ type BoxInputConfig struct {
 	// "*" will be used.
 	InputName string
 
-	// Capacity is the maximum capacity (length) of input pipe. When this
-	// parameter is 0, the default value is used. This parameter is only used
-	// as a hint and doesn't guarantee that the pipe can actually have the
-	// specified number of tuples.
+	// Capacity is the maximum capacity or buffer size (length) of input pipe.
+	// When this parameter is 0, the default value is used. This parameter is
+	// only used as a hint and doesn't guarantee that the pipe can actually have
+	// the specified number of tuples.
 	Capacity int
 
 	// DropMode is a mode which controls the behavior of dropping tuples at the
 	// output side of the queue when it is full.
 	DropMode QueueDropMode
+}
+
+// Validate validates values of BoxInputConfig.
+func (c *BoxInputConfig) Validate() error {
+	return validateCapacity(c.Capacity)
 }
 
 func (c *BoxInputConfig) inputName() string {
@@ -336,6 +356,11 @@ type SinkInputConfig struct {
 	// DropMode is a mode which controls the behavior of dropping tuples at the
 	// output side of the queue when it is full.
 	DropMode QueueDropMode
+}
+
+// Validate validates values of SinkInputConfig.
+func (c *SinkInputConfig) Validate() error {
+	return validateCapacity(c.Capacity)
 }
 
 func (c *SinkInputConfig) capacity() int {

--- a/core/node_test.go
+++ b/core/node_test.go
@@ -46,3 +46,29 @@ func TestValidateSymbol(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateCapacity(t *testing.T) {
+	Convey("Given validateCapacity function", t, func() {
+		Convey("When passing a valid value to it", func() {
+			Convey("Then it should accept 0", func() {
+				So(validateCapacity(0), ShouldBeNil)
+			})
+
+			Convey("Then it should accept a maximum value", func() {
+				So(validateCapacity(MaxCapacity), ShouldBeNil)
+			})
+		})
+
+		Convey("When passing a too large value", func() {
+			Convey("Then it should fail", func() {
+				So(validateCapacity(MaxCapacity+1), ShouldNotBeNil)
+			})
+		})
+
+		Convey("When passing a negative value", func() {
+			Convey("Then it should fail", func() {
+				So(validateCapacity(-1), ShouldNotBeNil)
+			})
+		})
+	})
+}


### PR DESCRIPTION
I moved `MaxBufferSize` to `core` package and changed its name to `MaxCapacity` to be consistent in `core` package. It'd probably be better to rename `Capacity` in `core` package to `BufferSize`, but I wasn't sure enough and just moved the constant in this PR.

fixes #37 