### PR TITLE
Support output format in bql shell

### DIFF
--- a/cmd/lib/shell/cmd_line_tool.go
+++ b/cmd/lib/shell/cmd_line_tool.go
@@ -37,7 +37,22 @@ var CmdFlags = []cli.Flag{
 		Name:  "topology,t",
 		Usage: "the SensorBee topology to use (instead of USE command)",
 	},
+	cli.StringFlag{
+		Name:  "output-format",
+		Value: "bql",
+		Usage: "the format of the output of BQL statements (bql or json)",
+	},
 }
+
+// Global flags to control behavior of the shell.
+// TODO: support dynamic modification of outputFormat.
+var (
+	outputFormat       = "bql"
+	validOutputFormats = map[string]struct{}{
+		"json": struct{}{},
+		"bql":  struct{}{},
+	}
+)
 
 // Launch SensorBee's command line client tool.
 func Launch(c *cli.Context) error {
@@ -45,6 +60,7 @@ func Launch(c *cli.Context) error {
 		if err := validateFlags(c); err != nil {
 			return err
 		}
+		outputFormat = c.String("output-format")
 		if c.IsSet("topology") {
 			currentTopology.name = c.String("topology")
 		}
@@ -76,7 +92,11 @@ func validateFlags(c *cli.Context) error {
 	if err := client.ValidateAPIVersion(c.String("api-version")); err != nil {
 		return err
 	}
-	// TODO: check other flags
+
+	of := c.String("output-format")
+	if _, ok := validOutputFormats[of]; !ok {
+		return fmt.Errorf("invalid output format: %v", of)
+	}
 	return nil
 }
 

--- a/cmd/lib/shell/cmd_topologies.go
+++ b/cmd/lib/shell/cmd_topologies.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"gopkg.in/sensorbee/sensorbee.v0/client"
@@ -140,19 +141,24 @@ func sendBQLQueries(requester *client.Requester, queries string) {
 	if err == nil {
 		result, ok := data["result"]
 		if ok {
-			printJSONResult(result)
+			printResult(result)
 		}
 	}
 
 }
 
-// printJSONResult prints a result in JSON format. This function directly print
+// printResult prints a result in JSON or BQL format. This function directly print
 // an error message on failure and doesn't return an error.
-func printJSONResult(v interface{}) {
+func printResult(v interface{}) {
 	data, err := json.Marshal(v)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cannot marshal the result into a JSON: %v\n", err)
 		return
+	}
+
+	// switch the output format depending on the global flag
+	if outputFormat == "bql" {
+		data = bytes.Replace(data, []byte(`\"`), []byte(`""`), -1)
 	}
 	fmt.Printf("%s\n", data)
 }
@@ -174,7 +180,7 @@ func showStreamResponses(res *client.Response) {
 			if !ok {
 				return
 			}
-			printJSONResult(js)
+			printResult(js)
 
 		case <-sig:
 			return // The response is closed by the caller


### PR DESCRIPTION
The shell now supports JSON and BQL formatting. However, it cannot dynamically be changed at runtime.

fixes #58 