### PR TITLE
Add access logging of request sent through WebSocket

### DIFF
--- a/server/topologies.go
+++ b/server/topologies.go
@@ -654,10 +654,9 @@ func (tc *topologies) processWebSocketMessage(conn *websocket.Conn, tb *bql.Topo
 		w.rid = r
 	}
 
-	// TODO: access logging
-
 	// rid should be logged from this point. So, following logging should be
 	// done by w.Log/w.ErrLog.
+	w.Log().Info("Request via WebSocket")
 
 	if v, ok := form["payload"]; !ok {
 		w.Log().Error("The required 'payload' field is missing")


### PR DESCRIPTION
I added access logging. Payloads should probably be included but I didn't do it for the moment.