### PR TITLE
Set the capacity of the SELECT sink to 1 temporarily

### DIFF
--- a/bql/topology_builder.go
+++ b/bql/topology_builder.go
@@ -735,7 +735,13 @@ func (tb *TopologyBuilder) AddSelectUnionStmt(stmts *parser.SelectUnionStmt) (co
 			box.(core.BoxNode).RemoveOnStop()
 
 			// now connect the sink to that box
-			if err := sink.Input(tmpName, nil); err != nil {
+			if err := sink.Input(tmpName, &core.SinkInputConfig{
+				// TODO: Make this confgurable in the SELECT statement
+				// The pipe can be full when the network is too slow and it's
+				// critical for small devices that doesn't have much memory.
+				// Therefore, the Capacity here is set to 1 for the moment.
+				Capacity: 1,
+			}); err != nil {
 				tb.topology.Remove(tmpName)
 				return nil, err
 			}


### PR DESCRIPTION
When streaming video frames from RPi, the process is easily killed by OOM if the receiver can't consume tuples fast enough. Although users can specify `BUFFER SIZE` and `DROP IF` in the SELECT statement, there's no way to specify those parameters for the Sink connected to the SELECT BQL box.

This problem should be solved by adding a way in SELECT (and perhaps INSERT INTO) statements to specify buffer size and drop mode, but it's temporarily fixed by setting 1 to the buffer size (i.e. capacity).