### PR TITLE
Add blob_to_raw_string built-in UDF

### DIFF
--- a/bql/udf/builtin/conversion.go
+++ b/bql/udf/builtin/conversion.go
@@ -1,0 +1,16 @@
+package builtin
+
+import (
+	"errors"
+	"gopkg.in/sensorbee/sensorbee.v0/data"
+	"unicode/utf8"
+)
+
+// blobToRawString converts a blob to a string without encoding the value in
+// base64. It returns an error when the blob contains invalid UTF-8 runes.
+func blobToRawString(b data.Blob) (data.String, error) {
+	if !utf8.Valid([]byte(b)) {
+		return data.String(""), errors.New("blob contains invalid UTF-8 runes")
+	}
+	return data.String(b), nil
+}

--- a/bql/udf/builtin/conversion_test.go
+++ b/bql/udf/builtin/conversion_test.go
@@ -1,0 +1,60 @@
+package builtin
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/sensorbee/sensorbee.v0/bql/udf"
+	"gopkg.in/sensorbee/sensorbee.v0/core"
+	"gopkg.in/sensorbee/sensorbee.v0/data"
+	"testing"
+)
+
+func TestBlobToString(t *testing.T) {
+	ctx := core.NewContext(nil)
+	Convey("Given blob_to_string UDF", t, func() {
+		Convey("When passing valid values", func() {
+			Convey("Then it should accept an empty blob", func() {
+				s, err := blobToRawString(data.Blob(""))
+				So(err, ShouldBeNil)
+				So(string(s), ShouldBeBlank)
+			})
+
+			Convey("Then it should accept JSON", func() {
+				a := `{
+					"a": 1,
+					"b": "2",
+					"c": [3.4, "5", {"6": 7}]
+				}`
+				s, err := blobToRawString(data.Blob(a))
+				So(err, ShouldBeNil)
+				So(string(s), ShouldEqual, a)
+			})
+
+			Convey("Then it should accept Japanese", func() {
+				a := "日本語でおｋ"
+				s, err := blobToRawString(data.Blob(a))
+				So(err, ShouldBeNil)
+				So(string(s), ShouldEqual, a)
+			})
+		})
+
+		Convey("When passing invalid values", func() {
+			Convey("Then it should reject binary values", func() {
+				_, err := blobToRawString(data.Blob{1, 0xff, 3})
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Then it should reject a broken string", func() {
+				b := data.Blob("日本語でおｋ")
+				b[5] = 0
+				_, err := blobToRawString(b)
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Then it should reject invalid types", func() {
+				f := udf.MustConvertGeneric(blobToRawString)
+				_, err := f.Call(ctx, data.Map{})
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+}

--- a/bql/udf/builtin/init.go
+++ b/bql/udf/builtin/init.go
@@ -74,6 +74,8 @@ func init() {
 	udf.RegisterGlobalUDF("min", minFunc)
 	udf.RegisterGlobalUDF("string_agg", stringAggFunc)
 	udf.RegisterGlobalUDF("sum", sumFunc)
+	// conversion functions
+	udf.RegisterGlobalUDF("blob_to_raw_string", udf.MustConvertGeneric(blobToRawString))
 	// other functions
 	udf.RegisterGlobalUDF("coalesce", coalesceFunc)
 }


### PR DESCRIPTION
I added blob_to_raw_string UDF. This UDF is used when a user wants to convert a blob to a string without using base64 encoding. Because it's invalid for a string to have non UTF-8 characters, this function validates the given data.Blob before converting it to data.String.