### PR TITLE
Support json.Number in data package

### DIFF
--- a/bql/udf/builtin/string.go
+++ b/bql/udf/builtin/string.go
@@ -628,7 +628,6 @@ func decodeJSON(ctx *core.Context, v data.Value) (data.Value, error) {
 	}
 
 	dec := json.NewDecoder(r)
-	// TODO: use json.Number after supporting it in data.NewValue
 	switch first {
 	case '[':
 		var a data.Array

--- a/bql/udf/builtin/string_test.go
+++ b/bql/udf/builtin/string_test.go
@@ -576,7 +576,7 @@ func TestDecodeJSON(t *testing.T) {
 			"b": [2.3, "4"]
 		}`
 		mapAnswer := data.Map{
-			"a": data.Float(1),
+			"a": data.Int(1),
 			"b": data.Array{data.Float(2.3), data.String("4")},
 		}
 		Convey("When passing JSON as string", func() {
@@ -599,7 +599,7 @@ func TestDecodeJSON(t *testing.T) {
 			Convey("Then it should decode an array", func() {
 				v, err := decodeJSON(nil, data.String(`[1,{"2":3.4},"5"]`))
 				So(err, ShouldBeNil)
-				So(v, ShouldResemble, data.Array{data.Float(1), data.Map{"2": data.Float(3.4)}, data.String("5")})
+				So(v, ShouldResemble, data.Array{data.Int(1), data.Map{"2": data.Float(3.4)}, data.String("5")})
 			})
 		})
 

--- a/data/array.go
+++ b/data/array.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -68,7 +69,9 @@ func (a Array) String() string {
 // UnmarshalJSON reconstructs an Array from JSON.
 func (a *Array) UnmarshalJSON(data []byte) error {
 	var j []interface{}
-	if err := json.Unmarshal(data, &j); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&j); err != nil {
 		return err
 	}
 

--- a/data/map.go
+++ b/data/map.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -65,7 +66,9 @@ func (m Map) String() string {
 // UnmarshalJSON reconstructs a Map from JSON.
 func (m *Map) UnmarshalJSON(data []byte) error {
 	var j map[string]interface{}
-	if err := json.Unmarshal(data, &j); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&j); err != nil {
 		return err
 	}
 

--- a/data/value.go
+++ b/data/value.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/ugorji/go/codec"
 	"math"
@@ -200,6 +201,16 @@ func NewValue(v interface{}) (Value, error) {
 			m[s] = v
 		}
 		return NewMap(m)
+	case json.Number:
+		// json.Number is a string and must be checked before the actual string type.
+		if i, err := vt.Int64(); err == nil {
+			return Int(i), nil
+		}
+		f, err := vt.Float64()
+		if err != nil {
+			return nil, err
+		}
+		return Float(f), nil
 	case bool:
 		return Bool(vt), nil
 	case int:


### PR DESCRIPTION
`data.NewValue` now supports `json.Number`. Also, `data.Array` and `data.Map` parse JSON with `json.Decoder.UseNumber` enabled.

fixes #106 