### PR TITLE
Add Array to Blob conversion when an array contains uint8 values

### DIFF
--- a/bql/udf/generic_func_test.go
+++ b/bql/udf/generic_func_test.go
@@ -3,13 +3,14 @@ package udf
 import (
 	"bytes"
 	"fmt"
-	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/sensorbee/sensorbee.v0/core"
-	"gopkg.in/sensorbee/sensorbee.v0/data"
 	"math"
 	"strings"
 	"testing"
 	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/sensorbee/sensorbee.v0/core"
+	"gopkg.in/sensorbee/sensorbee.v0/data"
 )
 
 func TestGenericFunc(t *testing.T) {
@@ -649,7 +650,6 @@ func TestGenericFuncInconvertibleType(t *testing.T) {
 			{"int", data.Int(1)},
 			{"float", data.Float(1.0)},
 			{"time", data.Timestamp(time.Date(2015, time.May, 1, 14, 27, 0, 0, time.UTC))},
-			{"array", data.Array([]data.Value{data.Int(10)})},
 			{"map", data.Map{"key": data.Int(10)}},
 		},
 		{ // timestamp

--- a/data/type_conversions.go
+++ b/data/type_conversions.go
@@ -255,8 +255,10 @@ func ToBlob(v Value) ([]byte, error) {
 		b := make([]byte, len(a))
 		for i, e := range a {
 			v, err := e.asInt()
-			if err != nil || !(0 <= v && v <= 255) {
-				return nil, fmt.Errorf("cannot convert %T to Blob value", v)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert %v to Blob value", e.Type())
+			} else if !(0 <= v && v <= 255) {
+				return nil, fmt.Errorf("cannot convert int to Blob value: %v", v)
 			}
 			b[i] = byte(v)
 		}

--- a/data/type_conversions.go
+++ b/data/type_conversions.go
@@ -250,6 +250,17 @@ func ToBlob(v Value) ([]byte, error) {
 		return base64.StdEncoding.DecodeString(val)
 	case TypeBlob:
 		return v.asBlob()
+	case TypeArray:
+		a, _ := v.asArray()
+		b := make([]byte, len(a))
+		for i, e := range a {
+			v, err := e.asInt()
+			if err != nil || !(0 <= v && v <= 255) {
+				return nil, fmt.Errorf("cannot convert %T to Blob value", v)
+			}
+			b[i] = byte(v)
+		}
+		return b, nil
 	default:
 		return nil, fmt.Errorf("cannot convert %T to Blob", v)
 	}

--- a/data/type_conversions_test.go
+++ b/data/type_conversions_test.go
@@ -2,10 +2,11 @@ package data
 
 import (
 	"fmt"
-	. "github.com/smartystreets/goconvey/convey"
 	"math"
 	"testing"
 	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 type convTestInput struct {
@@ -280,8 +281,10 @@ func TestToBlob(t *testing.T) {
 			{"now", Timestamp(time.Now()), nil},
 		},
 		"Array": {
-			{"empty", Array{}, nil},
-			{"non-empty", Array{Int(2), String("foo")}, nil},
+			{"empty", Array{}, []byte{}},
+			{"byte-array", Array{Int(1), Int(2), Int(3)}, []byte{1, 2, 3}},
+			{"too-large", Array{Int(1), Int(256)}, nil},
+			{"non-empty-invalid", Array{Int(2), String("foo")}, nil},
 		},
 		"Map": {
 			{"empty", Map{}, nil},


### PR DESCRIPTION
I added `Array` -> `Blob` conversion when the array only contains uint8 values.