### PR TITLE
Add log_destinationless_tuples option

### DIFF
--- a/cmd/lib/runfile/cmd.go
+++ b/cmd/lib/runfile/cmd.go
@@ -9,6 +9,11 @@ package runfile
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/Sirupsen/logrus"
 	"gopkg.in/sensorbee/sensorbee.v0/bql"
 	"gopkg.in/sensorbee/sensorbee.v0/bql/parser"
@@ -19,10 +24,6 @@ import (
 	"gopkg.in/sensorbee/sensorbee.v0/server/udsstorage"
 	"gopkg.in/urfave/cli.v1"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 // SetUp sets up a command for running single BQL file.
@@ -204,6 +205,7 @@ func setUpTopology(name string, logger *logrus.Logger, conf *config.Config, us u
 		Logger: logger,
 	}
 	cc.Flags.DroppedTupleLog.Set(conf.Logging.LogDroppedTuples)
+	cc.Flags.DestinationlessTupleLog.Set(conf.Logging.LogDestinationlessTuples)
 	cc.Flags.DroppedTupleSummarization.Set(conf.Logging.SummarizeDroppedTuples)
 
 	tp, err := core.NewDefaultTopology(core.NewContext(cc), name)

--- a/core/context.go
+++ b/core/context.go
@@ -2,12 +2,13 @@ package core
 
 import (
 	"errors"
-	"github.com/Sirupsen/logrus"
-	"gopkg.in/sensorbee/sensorbee.v0/data"
 	"path/filepath"
 	"runtime"
 	"sync"
 	"sync/atomic"
+
+	"github.com/Sirupsen/logrus"
+	"gopkg.in/sensorbee/sensorbee.v0/data"
 )
 
 var (
@@ -187,8 +188,18 @@ type ContextFlags struct {
 	TupleTrace AtomicFlag
 
 	// DroppedTupleLog is a flag which turns on/off logging of dropped tuple
-	// events.
+	// events. When DestinationlessTupleLog flag isn't set, Destinationless
+	// tuples are not logged even if this flag is set.
 	DroppedTupleLog AtomicFlag
+
+	// DestinationlessTupleLog is a flag which turns on/off logging of dropped
+	// tuple events. A destinationless tuple is one kind of dropped tuples that
+	// is generated when a source or a stream doesn't have any destination and,
+	// therefore, a tuple is dropped. It often happens when a topology isn't
+	// fully built.
+	//
+	// To log destinationless tuples, DroppedTupleLog flag also needs to be set.
+	DestinationlessTupleLog AtomicFlag
 
 	// DroppedTupleSummarization is a flag to trun on/off summarization of
 	// dropped tuple logging. If this flag is enabled, tuples being logged will

--- a/core/pipe.go
+++ b/core/pipe.go
@@ -3,10 +3,11 @@ package core
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/sensorbee/sensorbee.v0/data"
 	"reflect"
 	"sync"
 	"sync/atomic"
+
+	"gopkg.in/sensorbee/sensorbee.v0/data"
 )
 
 func newPipe(inputName string, capacity int) (*pipeReceiver, *pipeSender) {
@@ -815,7 +816,9 @@ func (d *dataDestinations) Write(ctx *Context, t *Tuple) error {
 
 	if len(d.dsts) == 0 {
 		atomic.AddInt64(&d.numDropped, 1)
-		ctx.droppedTuple(t, d.nodeType, d.nodeName, ETOutput, errors.New("no output destination is connected"))
+		if ctx.Flags.DestinationlessTupleLog.Enabled() {
+			ctx.droppedTuple(t, d.nodeType, d.nodeName, ETOutput, errors.New("no output destination is connected"))
+		}
 		return nil
 	}
 

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -1,9 +1,10 @@
 package config
 
 import (
+	"testing"
+
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/sensorbee/sensorbee.v0/data"
-	"testing"
 )
 
 func TestConfig(t *testing.T) {
@@ -73,10 +74,11 @@ func TestConfigToMap(t *testing.T) {
 				},
 			},
 			Logging: &Logging{
-				Target:                 "stderr",
-				MinLogLevel:            "info",
-				LogDroppedTuples:       true,
-				SummarizeDroppedTuples: true,
+				Target:                   "stderr",
+				MinLogLevel:              "info",
+				LogDroppedTuples:         true,
+				LogDestinationlessTuples: true,
+				SummarizeDroppedTuples:   true,
 			},
 		}
 		Convey("When convert to data.Map", func() {
@@ -103,10 +105,11 @@ func TestConfigToMap(t *testing.T) {
 						},
 					},
 					"logging": data.Map{
-						"target":                   data.String("stderr"),
-						"min_log_level":            data.String("info"),
-						"log_dropped_tuples":       data.True,
-						"summarize_dropped_tuples": data.True,
+						"target":                     data.String("stderr"),
+						"min_log_level":              data.String("info"),
+						"log_dropped_tuples":         data.True,
+						"log_destinationless_tuples": data.True,
+						"summarize_dropped_tuples":   data.True,
 					},
 				}
 				So(ac, ShouldResemble, ex)

--- a/server/config/logging_test.go
+++ b/server/config/logging_test.go
@@ -2,15 +2,16 @@ package config
 
 import (
 	"fmt"
-	. "github.com/smartystreets/goconvey/convey"
 	"os"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestLogging(t *testing.T) {
 	Convey("Given a JSON config for logging section", t, func() {
 		Convey("When the config is valid", func() {
-			l, err := NewLogging(toMap(`{"target":"stdout","min_log_level":"error","log_dropped_tuples":true,"summarize_dropped_tuples":true}`))
+			l, err := NewLogging(toMap(`{"target":"stdout","min_log_level":"error","log_dropped_tuples":true,"log_destinationless_tuples":true,"summarize_dropped_tuples":true}`))
 			So(err, ShouldBeNil)
 
 			Convey("Then it should have given parameters", func() {
@@ -91,6 +92,23 @@ func TestLogging(t *testing.T) {
 			for _, v := range [][]interface{}{{"an integer", 1}, {"a string", `"true"`}} {
 				Convey(fmt.Sprintf("Then it should reject %v value", v[0]), func() {
 					_, err := NewLogging(toMap(fmt.Sprintf(`{"target":"stderr","log_dropped_tuples":%v}`, v[1])))
+					So(err, ShouldNotBeNil)
+				})
+			}
+		})
+
+		Convey("When validating log_destinationless_tuples", func() {
+			for _, v := range []bool{true, false} {
+				Convey(fmt.Sprint("Then it should accept ", v), func() {
+					l, err := NewLogging(toMap(fmt.Sprintf(`{"target":"stderr","log_destinationless_tuples":%v}`, v)))
+					So(err, ShouldBeNil)
+					So(l.LogDestinationlessTuples, ShouldEqual, v)
+				})
+			}
+
+			for _, v := range [][]interface{}{{"an integer", 1}, {"a string", `"true"`}} {
+				Convey(fmt.Sprintf("Then it should reject %v value", v[0]), func() {
+					_, err := NewLogging(toMap(fmt.Sprintf(`{"target":"stderr","log_destinationless_tuples":%v}`, v[1])))
 					So(err, ShouldNotBeNil)
 				})
 			}

--- a/server/context.go
+++ b/server/context.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/gocraft/web"
 	"gopkg.in/pfnet/jasco.v1"
@@ -12,8 +15,6 @@ import (
 	"gopkg.in/sensorbee/sensorbee.v0/data"
 	"gopkg.in/sensorbee/sensorbee.v0/server/config"
 	"gopkg.in/sensorbee/sensorbee.v0/server/udsstorage"
-	"io"
-	"io/ioutil"
 )
 
 // Context is a context object for gocraft/web.
@@ -174,6 +175,7 @@ func setUpTopology(logger *logrus.Logger, name string, conf *config.Config, us u
 		Logger: logger,
 	}
 	cc.Flags.DroppedTupleLog.Set(conf.Logging.LogDroppedTuples)
+	cc.Flags.DestinationlessTupleLog.Set(conf.Logging.LogDestinationlessTuples)
 	cc.Flags.DroppedTupleSummarization.Set(conf.Logging.SummarizeDroppedTuples)
 
 	tp, err := core.NewDefaultTopology(core.NewContext(cc), name)

--- a/server/topologies.go
+++ b/server/topologies.go
@@ -2,6 +2,14 @@ package server
 
 import (
 	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/gocraft/web"
 	"golang.org/x/net/websocket"
@@ -11,13 +19,6 @@ import (
 	"gopkg.in/sensorbee/sensorbee.v0/core"
 	"gopkg.in/sensorbee/sensorbee.v0/data"
 	"gopkg.in/sensorbee/sensorbee.v0/server/response"
-	"io"
-	"mime/multipart"
-	"net/http"
-	"net/textproto"
-	"os"
-	"strings"
-	"time"
 )
 
 type topologies struct {
@@ -123,6 +124,7 @@ func (tc *topologies) Create(rw web.ResponseWriter, req *web.Request) {
 	}
 	// TODO: Be careful of race conditions on these fields.
 	cc.Flags.DroppedTupleLog.Set(tc.config.Logging.LogDroppedTuples)
+	cc.Flags.DestinationlessTupleLog.Set(tc.config.Logging.LogDestinationlessTuples)
 	cc.Flags.DroppedTupleSummarization.Set(tc.config.Logging.SummarizeDroppedTuples)
 
 	tp, err := core.NewDefaultTopology(core.NewContext(cc), name)


### PR DESCRIPTION
I added a new option: `log_destinationless_tuples`. A destinationless tuple is a kind of dropped tuples. It's dropped when a source or a stream doesn't have any destination. To enable destinationless tuple logging, both `log_destinationless_tuples` and `log_dropped_tuples` options need to be true. Only enabling `log_dropped_tuples` doesn't report destinationless tuples.

This is a breaking change but destinationless tuples will not be reported by default.

fixes #125 