### PR TITLE
Remove exp command from default subcommands

### DIFF
--- a/cmd/build_sensorbee/main.go
+++ b/cmd/build_sensorbee/main.go
@@ -3,15 +3,16 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/sensorbee/sensorbee.v0/version"
-	"gopkg.in/urfave/cli.v1"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"text/template"
+
+	"gopkg.in/sensorbee/sensorbee.v0/version"
+	"gopkg.in/urfave/cli.v1"
+	"gopkg.in/yaml.v2"
 )
 
 func main() {
@@ -218,6 +219,5 @@ func main() {
 )
 
 var (
-	defaultCommands = []string{"run", "shell", "topology", "exp",
-		"runfile"}
+	defaultCommands = []string{"run", "shell", "topology", "runfile"}
 )

--- a/cmd/build_sensorbee/main_test.go
+++ b/cmd/build_sensorbee/main_test.go
@@ -3,13 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
-	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/sensorbee/sensorbee.v0/version"
-	"gopkg.in/urfave/cli.v1"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/sensorbee/sensorbee.v0/version"
+	"gopkg.in/urfave/cli.v1"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -62,7 +63,6 @@ commands:
 						"run":      commandDetail{},
 						"shell":    commandDetail{},
 						"topology": commandDetail{},
-						"exp":      commandDetail{},
 						"runfile":  commandDetail{},
 					},
 					Version: version.Version,


### PR DESCRIPTION
I removed unofficial and experimental `exp` commands from the default command list of `build_sensorbee` to avoid confusion.