### PR TITLE
Fix empty array conversion in GenericFunc

### DIFF
--- a/bql/udf/function_registry.go
+++ b/bql/udf/function_registry.go
@@ -2,15 +2,16 @@ package udf
 
 import (
 	"fmt"
-	"gopkg.in/sensorbee/sensorbee.v0/core"
-	"gopkg.in/sensorbee/sensorbee.v0/data"
 	"strings"
 	"sync"
+
+	"gopkg.in/sensorbee/sensorbee.v0/core"
+	"gopkg.in/sensorbee/sensorbee.v0/data"
 )
 
 // UDF is an interface having a user defined function.
 type UDF interface {
-	// Call calls the UDF.
+	// Call calls the UDF. data.Values must not be nil.
 	Call(*core.Context, ...data.Value) (data.Value, error)
 
 	// Accept checks if the function accepts the given number of arguments

--- a/bql/udf/generic_func.go
+++ b/bql/udf/generic_func.go
@@ -3,11 +3,12 @@ package udf
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/sensorbee/sensorbee.v0/core"
-	"gopkg.in/sensorbee/sensorbee.v0/data"
 	"math"
 	"reflect"
 	"time"
+
+	"gopkg.in/sensorbee/sensorbee.v0/core"
+	"gopkg.in/sensorbee/sensorbee.v0/data"
 )
 
 // ConvertGeneric creates a new UDF from various form of functions. Arguments
@@ -377,7 +378,7 @@ func genericFuncArgumentConverter(t reflect.Type) (argumentConverter, error) {
 			if err != nil {
 				return nil, err
 			}
-			res := reflect.Zero(t)
+			res := reflect.MakeSlice(t, 0, len(a))
 			for _, elem := range a {
 				e, err := c(elem)
 				if err != nil {

--- a/bql/udf/generic_func.go
+++ b/bql/udf/generic_func.go
@@ -365,7 +365,17 @@ func genericFuncArgumentConverter(t reflect.Type) (argumentConverter, error) {
 		if elemType.Kind() == reflect.Uint8 {
 			// process this as a blob
 			return func(v data.Value) (interface{}, error) {
-				return data.ToBlob(v)
+				// This function explicitly returns nil to avoid returning
+				// nils having non-empty type information for later nil
+				// equality checks.
+				res, err := data.ToBlob(v)
+				if err != nil {
+					return nil, err
+				}
+				if res == nil {
+					return nil, err
+				}
+				return res, nil
 			}, nil
 		}
 
@@ -386,14 +396,21 @@ func genericFuncArgumentConverter(t reflect.Type) (argumentConverter, error) {
 				}
 				res = reflect.Append(res, reflect.ValueOf(e))
 			}
-			return res.Interface(), nil
+			return res.Interface(), nil // res will never be nil.
 		}, nil
 
 	default:
 		switch reflect.Zero(t).Interface().(type) {
 		case data.Map:
 			return func(v data.Value) (interface{}, error) {
-				return data.AsMap(v)
+				res, err := data.AsMap(v)
+				if err != nil {
+					return nil, err
+				}
+				if res == nil {
+					return nil, err
+				}
+				return res, nil
 			}, nil
 
 		case time.Time:
@@ -405,6 +422,9 @@ func genericFuncArgumentConverter(t reflect.Type) (argumentConverter, error) {
 			if t.Implements(reflect.TypeOf(data.NewValue).Out(0)) { // data.Value
 				// Zero(interface) returns nil and type assertion doesn't work for it.
 				return func(v data.Value) (interface{}, error) {
+					if v == nil {
+						return nil, nil // Erase type information (data.Value) from nil
+					}
 					return v, nil
 				}, nil
 			}

--- a/bql/udf/generic_func_test.go
+++ b/bql/udf/generic_func_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -806,6 +807,43 @@ func TestGenericTimeFunc(t *testing.T) {
 				t, err := data.ToTimestamp(v)
 				So(err, ShouldBeNil)
 				So(t, ShouldResemble, time.Unix(0, 0))
+			})
+		})
+	})
+}
+
+func TestGenericArrayFunc(t *testing.T) {
+	ctx := core.NewContext(nil)
+
+	Convey("Given a function receiving an array", t, func() {
+		f, err := ConvertGeneric(func(a data.Array) data.Array {
+			return a
+		})
+		So(err, ShouldBeNil)
+
+		Convey("When passing an empty array", func() {
+			v, err := f.Call(ctx, data.Array{})
+			So(err, ShouldBeNil)
+			So(reflect.ValueOf(v).IsNil(), ShouldBeFalse) // To detect an old bug
+
+			Convey("Then, it should return an empty array", func() {
+				So(v.Type(), ShouldNotEqual, data.TypeNull)
+				a, err := data.AsArray(v)
+				So(err, ShouldBeNil)
+				So(a, ShouldBeEmpty)
+			})
+		})
+
+		Convey("When passing a non-empty array", func() {
+			v, err := f.Call(ctx, data.Array{data.Int(1)})
+			So(err, ShouldBeNil)
+
+			Convey("Then, it should return nil", func() {
+				So(v.Type(), ShouldNotEqual, data.TypeNull)
+				a, err := data.AsArray(v)
+				So(err, ShouldBeNil)
+				So(len(a), ShouldEqual, 1)
+				So(a[0], ShouldEqual, 1)
 			})
 		})
 	})

--- a/data/type_conversions.go
+++ b/data/type_conversions.go
@@ -14,53 +14,79 @@ const (
 
 	// MinConvFloat64 is the smallest float64 that can be converted to int64
 	MinConvFloat64 = float64(math.MinInt64)
+
+	errNilConversionFormat = "cannot convert nil to %v"
 )
 
 // AsBool returns a bool value only when the type of Value is TypeBool,
 // otherwise it returns error.
 func AsBool(v Value) (bool, error) {
+	if v == nil {
+		return false, fmt.Errorf(errNilConversionFormat, TypeBool)
+	}
 	return v.asBool()
 }
 
 // AsInt returns an integer value only when the type of Value is TypeInt,
 // otherwise it returns error.
 func AsInt(v Value) (int64, error) {
+	if v == nil {
+		return 0, fmt.Errorf(errNilConversionFormat, TypeInt)
+	}
 	return v.asInt()
 }
 
 // AsFloat returns a float value only when the type of Value is TypeFloat,
 // otherwise it returns error.
 func AsFloat(v Value) (float64, error) {
+	if v == nil {
+		return 0, fmt.Errorf(errNilConversionFormat, TypeFloat)
+	}
 	return v.asFloat()
 }
 
 // AsString returns a string only when the type of Value is TypeString,
 // otherwise it returns error.
 func AsString(v Value) (string, error) {
+	if v == nil {
+		return "", fmt.Errorf(errNilConversionFormat, TypeString)
+	}
 	return v.asString()
 }
 
 // AsBlob returns an array of bytes only when the type of Value is TypeBlob,
 // otherwise it returns error.
 func AsBlob(v Value) ([]byte, error) {
+	if v == nil {
+		return nil, fmt.Errorf(errNilConversionFormat, TypeBlob)
+	}
 	return v.asBlob()
 }
 
 // AsTimestamp returns a time.Time only when the type of Value is TypeTime,
 // otherwise it returns error.
 func AsTimestamp(v Value) (time.Time, error) {
+	if v == nil {
+		return time.Time{}, fmt.Errorf(errNilConversionFormat, TypeTimestamp)
+	}
 	return v.asTimestamp()
 }
 
 // AsArray returns an array of Values only when the type of Value is TypeArray,
 // otherwise it returns error.
 func AsArray(v Value) (Array, error) {
+	if v == nil {
+		return nil, fmt.Errorf(errNilConversionFormat, TypeArray)
+	}
 	return v.asArray()
 }
 
 // AsMap returns a map of string keys and Values only when the type of Value is
 // TypeMap, otherwise it returns error.
 func AsMap(v Value) (Map, error) {
+	if v == nil {
+		return nil, fmt.Errorf(errNilConversionFormat, TypeMap)
+	}
 	return v.asMap()
 }
 

--- a/data/type_conversions_test.go
+++ b/data/type_conversions_test.go
@@ -444,3 +444,47 @@ func runConversionTestCases(t *testing.T,
 		})
 	}
 }
+
+func TestAsTypeWithNil(t *testing.T) {
+	Convey("Given AsType functions", t, func() {
+		Convey("Then passing nil to AsBool should fail", func() {
+			_, err := AsBool(nil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Then passing nil to AsInt should fail", func() {
+			_, err := AsInt(nil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Then passing nil to AsFloat should fail", func() {
+			_, err := AsFloat(nil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Then passing nil to AsString should fail", func() {
+			_, err := AsString(nil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Then passing nil to AsBlob should fail", func() {
+			_, err := AsBlob(nil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Then passing nil to AsTimestamp should fail", func() {
+			_, err := AsTimestamp(nil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Then passing nil to AsArray should fail", func() {
+			_, err := AsArray(nil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Then passing nil to AsMap should fail", func() {
+			_, err := AsMap(nil)
+			So(err, ShouldNotBeNil)
+		})
+	})
+}


### PR DESCRIPTION
The current version had a problem that passing an empty array to a UDF resulted in receiving `nil` instead of the empty array.

```
func F(a data.Array) data.Array {
  return a
}

udf.RegisterGlobalUDF("f", udf.MustConvertGeneric(F))

>>> EVAL f([]);
null
```

I fixed the root cause and other issues related to nil handling.