### PR TITLE
Support file rotation option on file sink

### DIFF
--- a/bql/builtin.go
+++ b/bql/builtin.go
@@ -276,6 +276,11 @@ func createFileSink(ctx *core.Context, ioParams *IOParams, params data.Map) (cor
 		if v.MaxBackups > 0 {
 			l.MaxBackups = v.MaxBackups
 		}
+		if _, err := os.Stat(v.Path); err == nil && v.Truncate {
+			if err := os.Truncate(v.Path, 0); err != nil {
+				return nil, err
+			}
+		}
 		w = &l
 	} else {
 		flags := os.O_WRONLY | os.O_APPEND | os.O_CREATE

--- a/bql/builtin.go
+++ b/bql/builtin.go
@@ -253,9 +253,9 @@ func createFileSink(ctx *core.Context, ioParams *IOParams, params data.Map) (cor
 		Path     string `bql:",required"`
 		Truncate bool
 		// rotate information
-		MaxSize    int `bql:"maxsize"`
-		MaxAge     int `bql:"maxage"`
-		MaxBackups int `bql:"maxbackups"`
+		MaxSize    int
+		MaxAge     int
+		MaxBackups int
 	}{
 		Truncate: false,
 		MaxSize:  0,

--- a/bql/builtin_test.go
+++ b/bql/builtin_test.go
@@ -2,15 +2,17 @@ package bql
 
 import (
 	"fmt"
-	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/sensorbee/sensorbee.v0/core"
-	"gopkg.in/sensorbee/sensorbee.v0/data"
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/sensorbee/sensorbee.v0/core"
+	"gopkg.in/sensorbee/sensorbee.v0/data"
 )
 
 type testFileWriter struct {
@@ -51,7 +53,7 @@ func TestFileSource(t *testing.T) {
 
 	// an empty line is intentionally included
 	_, err = io.WriteString(f, fmt.Sprintf(`{"int":1, "ts":%v}
- 
+
  {"int":2, "ts":%v}
   {"int":3, "ts":%v} `, nowTs, nowTs, nowTs))
 	f.Close()
@@ -251,6 +253,78 @@ func TestFileSource(t *testing.T) {
 				params["interval"] = data.Map{}
 				_, err := createFileSource(ctx, &IOParams{}, params)
 				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+}
+
+func TestFileSink(t *testing.T) {
+	ctx := core.NewContext(nil)
+	ioParams := &IOParams{}
+	Convey("Given a temp directory path", t, func() {
+		tdir, err := ioutil.TempDir("", "test_sb_file_sink")
+		So(err, ShouldBeNil)
+		Reset(func() {
+			os.RemoveAll(tdir)
+		})
+		Convey("When create file sink without path", func() {
+			params := data.Map{
+				"truncate": data.False,
+			}
+			_, err := createFileSink(ctx, ioParams, params)
+			Convey("Then the sink should not be created", func() {
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("When create file sink with required param", func() {
+			fn := filepath.Join(tdir, "file_sink.jsonl")
+			params := data.Map{
+				"path": data.String(fn),
+			}
+			si, err := createFileSink(ctx, ioParams, params)
+			So(err, ShouldBeNil)
+			Reset(func() {
+				si.Close(ctx)
+			})
+			_, err = os.Stat(fn)
+			So(err, ShouldBeNil)
+			Convey("And when write a tuple to the sink", func() {
+				d := data.Map{"k": data.Int(-1)}
+				tu := core.NewTuple(d)
+				So(si.Write(ctx, tu), ShouldBeNil)
+				Convey("Then the tuple should be written in the file", func() {
+					actualByte, err := ioutil.ReadFile(fn)
+					So(err, ShouldBeNil)
+					So(string(actualByte), ShouldEqual, `{"k":-1}
+`)
+				})
+			})
+		})
+
+		Convey("When create file sink with truncate flag", func() {
+			fn := filepath.Join(tdir, "file_sink2.jsonl")
+			So(ioutil.WriteFile(fn, []byte(`{"k":-2}
+`), 0644), ShouldBeNil)
+			params := data.Map{
+				"path":     data.String(fn),
+				"truncate": data.True,
+			}
+			si, err := createFileSink(ctx, ioParams, params)
+			So(err, ShouldBeNil)
+			Reset(func() {
+				si.Close(ctx)
+			})
+			Convey("And when write a tuple to the sink", func() {
+				d := data.Map{"k": data.Int(-1)}
+				tu := core.NewTuple(d)
+				So(si.Write(ctx, tu), ShouldBeNil)
+				Convey("Then the tuple should be written in the file", func() {
+					actualByte, err := ioutil.ReadFile(fn)
+					So(err, ShouldBeNil)
+					So(string(actualByte), ShouldEqual, `{"k":-1}
+`)
+				})
 			})
 		})
 	})


### PR DESCRIPTION
- use `data.Decoder` on file sink and file source
- support file rotation option on file sink, using lumberjack which has already used on server/log.