### PR TITLE
Only Support Go 1.8 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ script:
   - gotestcover -v -covermode=count -coverprofile=.profile.cov -parallelpackages=1 ./...
 
 after_success:
-  - if [ "$TRAVIS_GO_VERSION" = "1.7.1" ]; then goveralls -coverprofile=.profile.cov -repotoken $COVERALLS_TOKEN; fi
+  - goveralls -coverprofile=.profile.cov -repotoken $COVERALLS_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: go
 go:
-  - 1.4.3
-  - 1.5.4
-  - 1.6.3
-  - 1.7.1
+  - 1.8.x
 
 sudo: false
 


### PR DESCRIPTION
From next version, SensorBee only supports Go 1.8 or later.

fixes #119 