### PR TITLE
Lowercased logrus repository dep

### DIFF
--- a/bql/bql_box.go
+++ b/bql/bql_box.go
@@ -1,7 +1,7 @@
 package bql
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/sensorbee/sensorbee.v0/bql/execution"
 	"gopkg.in/sensorbee/sensorbee.v0/bql/parser"
 	"gopkg.in/sensorbee/sensorbee.v0/bql/udf"

--- a/cmd/lib/runfile/cmd.go
+++ b/cmd/lib/runfile/cmd.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/sensorbee/sensorbee.v0/bql"
 	"gopkg.in/sensorbee/sensorbee.v0/bql/parser"
 	"gopkg.in/sensorbee/sensorbee.v0/bql/udf"

--- a/core/context.go
+++ b/core/context.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/sensorbee/sensorbee.v0/data"
 )
 

--- a/core/node.go
+++ b/core/node.go
@@ -2,7 +2,7 @@ package core
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/sensorbee/sensorbee.v0/data"
 	"regexp"
 	"strings"

--- a/server/context.go
+++ b/server/context.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/gocraft/web"
 	"gopkg.in/pfnet/jasco.v1"
 	"gopkg.in/sensorbee/sensorbee.v0/bql"

--- a/server/topologies.go
+++ b/server/topologies.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/gocraft/web"
 	"golang.org/x/net/websocket"
 	"gopkg.in/pfnet/jasco.v1"


### PR DESCRIPTION
Hi.

This PR syncs @sirupsen lowercasing his logrus repository name which is now

`https://github.com/sirupsen/logrus`

> Seeing weird case-sensitive problems? It's in the past been possible to import Logrus as both upper- and lower-case. Due to the Go package environment, this caused issues in the community and we needed a standard. Some environments experienced problems with the upper-case variant, so the lower-case was decided. Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.